### PR TITLE
in-memory cache & option for persistent cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,12 +1,10 @@
 
 __pycache__
-/examples/user.json
-/examples/config.py
-log.txt
 .DS_Store
 .idea
 __pycache__/
 **/.DS_Store
 /build
 /dist
-/env
+.coverage
+scripts/htmlpage/

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2022-01-16T15:47:59Z",
+  "generated_at": "2022-02-22T09:18:19Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -70,7 +70,16 @@
         "hashed_secret": "d4c3d66fd0c38547a3c7a4c6bdc29c36911bc030",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 42,
+        "line_number": 40,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "examples/README.md": [
+      {
+        "hashed_secret": "c3ce73b77a9c19a12ad72ac85a723c71b8dcb8cc",
+        "is_verified": false,
+        "line_number": 17,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/examples/README.md
+++ b/examples/README.md
@@ -8,4 +8,13 @@ To run the examples, you will need the appropriate service instance
    4. Create a new Environment or use the "dev".
    5. Create a collection and copy the Id value.
 
- Add the above values to `config.py` file.
+ Create a file name `config.py` in the same folder. And add the above values to it
+ Example:
+ ```python
+# config.py
+
+GUID = "paste-the-guid"
+APIKEY = "paste-the-apikey"
+COLLECTION = "collection_id"
+ENVIRONMENT = "environment-id"
+```

--- a/examples/sample_app.py
+++ b/examples/sample_app.py
@@ -21,10 +21,10 @@ class Window(tk.Tk):
     def __init__(self):
         super().__init__()
 
-        self.__haData = False
+        self.__hasData = False
         self.title("App Configuration sample")
         self.label_text = tk.StringVar()
-        self.label_text.set('Get your Feature value after data is loaded')
+        self.label_text.set('Get your Configuration values after data is loaded')
 
         self.label = tk.Label(self, textvar=self.label_text)
         self.label.pack(fill=tk.BOTH, expand=1, padx=100, pady=30)
@@ -33,7 +33,7 @@ class Window(tk.Tk):
         hello_button.pack(side=tk.LEFT, padx=(10, 20), pady=(0, 20))
 
         numeric_button = tk.Button(self, text="Get Numeric Feature",
-                                    command=lambda: self.fetch_feature('featurenumeric'))
+                                   command=lambda: self.fetch_feature('featurenumeric'))
         numeric_button.pack(side=tk.LEFT, padx=(10, 20), pady=(0, 20))
 
         bool_button = tk.Button(self, text="Get Boolean Feature", command=lambda: self.fetch_feature('featurebool'))
@@ -45,7 +45,7 @@ class Window(tk.Tk):
         self.initialize_app()
 
     def fetch_property(self, property_id: str):
-        if self.__haData:
+        if self.__hasData:
             self.label.configure(background="red")
             app_config = AppConfiguration.get_instance()
             property_obj = app_config.get_property(property_id)
@@ -70,7 +70,7 @@ class Window(tk.Tk):
             self.label.configure(background="grey")
 
     def fetch_feature(self, feature_id: str):
-        if self.__haData:
+        if self.__hasData:
             self.label.configure(background="red")
             app_config = AppConfiguration.get_instance()
             feature = app_config.get_feature(feature_id)
@@ -103,18 +103,17 @@ class Window(tk.Tk):
             self.label.configure(background="red")
 
     def response(self):
-        self.__haData = True
+        self.__hasData = True
         self.label_text.set('Get your Feature value NOW')
 
-    def initialize_app(self, isOnLine: bool = True):
-        app_config = AppConfiguration.get_instance()
-        #app_config.override_server_host = config.URL
+    def initialize_app(self):
+        appconfig_client = AppConfiguration.get_instance()
         AppConfiguration.enable_debug(True)
-        app_config.init(region=AppConfiguration.REGION_US_SOUTH,
-                        guid=config.GUID,
-                        apikey=config.APIKEY)
-        app_config.set_context(collection_id=config.COLLECTION, environment_id=config.ENV1, configuration_file=config.FILE, live_config_update_enabled=isOnLine)
-        app_config.register_configuration_update_listener(self.response)
+        appconfig_client.init(region=AppConfiguration.REGION_US_SOUTH,
+                              guid=config.GUID,
+                              apikey=config.APIKEY)
+        appconfig_client.set_context(collection_id=config.COLLECTION, environment_id=config.ENVIRONMENT)
+        appconfig_client.register_configuration_update_listener(self.response)
         self.response()
 
 

--- a/examples/server_sample.py
+++ b/examples/server_sample.py
@@ -27,15 +27,14 @@ def response():
 
 
 def setup() -> None:
-    app_config = AppConfiguration.get_instance()
-    app_config.init(region=AppConfiguration.REGION_US_SOUTH,
-                    guid=config.GUID,
-                    apikey=config.APIKEY)
-    app_config.set_context(collection_id=config.COLLECTION, environment_id=config.ENV1,
-                           configuration_file=config.FILE, live_config_update_enabled=True)
+    appconfig_client = AppConfiguration.get_instance()
+    appconfig_client.init(region=AppConfiguration.REGION_US_SOUTH,
+                          guid=config.GUID,
+                          apikey=config.APIKEY)
+    appconfig_client.set_context(collection_id=config.COLLECTION, environment_id=config.ENVIRONMENT)
 
 
-def fetch_feature(feature_id: str, request_object=None) -> str:
+def fetch_feature(feature_id: str) -> str:
     if has_data:
         app_config = AppConfiguration.get_instance()
         feature = app_config.get_feature(feature_id)
@@ -112,7 +111,7 @@ class MockServer(BaseHTTPRequestHandler):
     def do_POST(self):
         value = "POST!"
         if has_data:
-            value = fetch_feature("featurestring", self)
+            value = fetch_feature("featurestring")
         self._set_headers()
         self.wfile.write(_html(value))
 

--- a/ibm_appconfiguration/configurations/internal/common/config_messages.py
+++ b/ibm_appconfiguration/configurations/internal/common/config_messages.py
@@ -22,14 +22,19 @@ APIKEY_ERROR = "Provide a valid apiKey in App Configuration init"
 COLLECTION_ID_VALUE_ERROR = "Provide a valid collection_id in App Configuration set_context method"
 ENVIRONMENT_ID_VALUE_ERROR = "Provide a valid environment_id in App Configuration set_context method"
 COLLECTION_INIT_ERROR = "Invalid action in App Configuration. This action can be performed only after a successful " \
-                       "initialization operation. Please check the initialization section for errors. "
-CONFIGURATION_FILE_NOT_FOUND_ERROR = "configuration_file parameter should be provided while " \
-                                     "live_config_update_enabled is false in set_context method."
+                        "initialization operation. Please check the initialization section for errors. "
+SET_CONTEXT_OPTIONAL_ARGUMENTS_ERROR = "Invalid optional parameters passed to set_context method. Either wrong arguments keys or invalid value of arguments passed. " \
+                                       "The only available arguments are persistent_cache_dir(str), bootstrap_file(str) & live_config_update_enabled(bool)." \
+                                       "Please check the sdk initialization section in the readme."
+DEPRECATION_WARNING_MESSAGE = "DeprecationWarning: With v0.2.3, the existing method of passing the optional arguments `configuration_file` & `live_config_update_enabled` to set_context method is deprecated and will be removed from v0.3.0 Use the options argument instead."
+ERROR_NO_WRITE_PERMISSION = "Persistent cache directory provided does not have write permission. Make sure the directory has required access",
+BOOTSTRAP_FILE_NOT_FOUND_ERROR = "Provide a valid bootstrap_file path while live_config_update_enabled is false in set_context method."
 CONFIGURATION_HANDLER_INIT_ERROR = 'Invalid action in ConfigurationHandler. This action can be performed only after a ' \
                                    'successful initialization. Please check the initialization section for errors. '
 CONFIGURATION_HANDLER_METHOD_ERROR = "Invalid action in ConfigurationHandler. Should be a method/function"
-CONFIGURATION_API_ERROR = "Invalid configuration. Verify the collection_id, environment_id, apikey, guid and region."
 SINGLETON_EXCEPTION = "class must be initialized using the get_instance() method."
 FEATURE_INVALID = "Invalid feature_id - "
 NO_INTERNET_CONNECTION_ERROR = 'No connection to internet. Please re-connect.'
 PROPERTY_INVALID = "Invalid property_id - "
+CONFIGURATIONS_FETCH_SUCCESS = "Successfully fetched the configurations."
+RETRY_AFTER_TEN_MINUTES = "Failed to fetch the configurations. Retrying after 10 minutes."

--- a/ibm_appconfiguration/configurations/internal/utils/api_manager.py
+++ b/ibm_appconfiguration/configurations/internal/utils/api_manager.py
@@ -37,13 +37,9 @@ class APIManager(BaseService):
         return APIManager.__instance
 
     def __init__(self):
-        Logger.debug("Initialised _BaseRequest")
-
-    def setup_base(self):
-        """SetUp the Base class with service_url and authenticator"""
-        BaseService.__init__(self,
-                             service_url=URLBuilder.get_base_url(),
-                             authenticator=URLBuilder.get_iam_authenticator())
+        super().__init__(service_url=URLBuilder.get_base_url(),
+                         authenticator=URLBuilder.get_iam_authenticator())
+        APIManager.__instance = self
 
     def prepare_api_request(self,
                             method: str,
@@ -59,22 +55,21 @@ class APIManager(BaseService):
             return the DetailedResponse.
         """
 
-        headers = {}
+        headers = {'Content-Type': 'application/json',
+                   'User-Agent': '{0}/{1}'.format(config_constants.SDK_NAME, __version__)}
         if data and isinstance(data, dict):
             data = self.__remove_null_values(data)
-            headers['Content-Type'] = 'application/json'
-            headers['User-Agent'] =  '{0}/{1}'.format(config_constants.SDK_NAME, __version__)
             data = json_import.dumps(data)
 
         try:
             request = self.prepare_request(method=method,
-                                       url=url,
-                                       headers=headers,
-                                       data=data)
+                                           url=url,
+                                           headers=headers,
+                                           data=data)
             response = self.send(request)
             return response
         except ApiException as api_exception:
-            return DetailedResponse(response=None,
+            return DetailedResponse(response=api_exception.message,
                                     headers=None,
                                     status_code=api_exception.code)
         except Exception as exception:

--- a/ibm_appconfiguration/configurations/internal/utils/connectivity.py
+++ b/ibm_appconfiguration/configurations/internal/utils/connectivity.py
@@ -20,6 +20,7 @@ from threading import Timer
 import requests
 from .url_builder import URLBuilder
 
+
 class Connectivity:
     """Connectivity checker"""
     __instance = None

--- a/ibm_appconfiguration/configurations/internal/utils/file_manager.py
+++ b/ibm_appconfiguration/configurations/internal/utils/file_manager.py
@@ -19,8 +19,8 @@ file based cache of the SDK.
 
 import fcntl
 import json
-import os
-from typing import Optional
+from typing import Optional, Any
+
 from .logger import Logger
 
 
@@ -28,50 +28,40 @@ class FileManager:
     """FileManager to handle the cache"""
 
     @classmethod
-    def store_files(cls, json_data: {}, file_path: Optional[str] = None) -> bool:
+    def store_files(cls, json_data: {}, file_path: str) -> bool:
         """Store the file
 
         Args:
             json_data: Data to be stored.
             file_path: File path for the cache.
         """
-        cache_loc = ''
-        if file_path is not None:
-            cache_loc = file_path
-        else:
-            cache_loc = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'appconfiguration.json')
         try:
-            with open(cache_loc, 'w') as cache:
+            with open(file_path, 'w') as cache:
                 fcntl.flock(cache, fcntl.LOCK_EX | fcntl.LOCK_NB)
                 json.dump(json_data, cache)
                 fcntl.flock(cache, fcntl.LOCK_UN)
                 return True
         except Exception as err:
-            Logger.debug(err)
+            Logger.error(err)
             return False
 
     @classmethod
-    def read_files(cls, file_path: Optional[str] = None) -> dict:
+    def read_files(cls, file_path: str) -> Optional[Any]:
         """
-        Read the data from the cache.
+        Read the data from the given path.
 
         Args:
-            file_path: File path for the cache.
+            file_path: Path of the file
         Returns:
-            Dictionary from the cache.
+            Dictionary.
         """
-        cache_loc = ''
-        if file_path is not None:
-            cache_loc = file_path
-        else:
-            cache_loc = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'appconfiguration.json')
 
         try:
-            with open(cache_loc, 'r') as cache:
-                fcntl.flock(cache, fcntl.LOCK_EX | fcntl.LOCK_NB)
-                data = json.load(cache)
-                fcntl.flock(cache, fcntl.LOCK_UN)
+            with open(file_path, 'r') as file:
+                fcntl.flock(file, fcntl.LOCK_EX | fcntl.LOCK_NB)
+                data = json.load(file)
+                fcntl.flock(file, fcntl.LOCK_UN)
                 return data
         except Exception as err:
-            Logger.debug(err)
+            Logger.error(err)
             return None

--- a/ibm_appconfiguration/configurations/internal/utils/logger.py
+++ b/ibm_appconfiguration/configurations/internal/utils/logger.py
@@ -29,13 +29,10 @@ def setup_custom_logger(name: str):
     """
     formatter = logging.Formatter(fmt='%(asctime)s AppConfiguration %(levelname)-8s %(message)s',
                                   datefmt='%Y-%m-%d %H:%M:%S')
-    handler = logging.FileHandler('log.txt', mode='w')
-    handler.setFormatter(formatter)
     screen_handler = logging.StreamHandler(stream=sys.stdout)
     screen_handler.setFormatter(formatter)
     logger = logging.getLogger(name)
     logger.setLevel(logging.DEBUG)
-    logger.addHandler(handler)
     logger.addHandler(screen_handler)
     return logger
 
@@ -44,7 +41,7 @@ class Logger:
     """Logger for the library"""
     __is_debug = False
 
-    __AppLogger = setup_custom_logger("app_rapp_logger")
+    __AppLogger = setup_custom_logger("appconfig_logger")
 
     class LoggerColors:
         """Logger Colors"""

--- a/ibm_appconfiguration/configurations/internal/utils/url_builder.py
+++ b/ibm_appconfiguration/configurations/internal/utils/url_builder.py
@@ -15,6 +15,7 @@
 """
 This module provides methods to construct different url used by the SDK.
 """
+from typing import Optional
 from ibm_cloud_sdk_core.authenticators import IAMAuthenticator, NoAuthAuthenticator, Authenticator
 from .validators import Validators
 from ..common import config_constants
@@ -34,6 +35,7 @@ class URLBuilder:
     __config_base = ''
     __iam_authenticator = None
     __hasAuth = True
+    __network_check_url = 'https://cloud.ibm.com'
 
     @classmethod
     def init_with_collection_id(cls, collection_id='', region='', guid='', environment_id='', override_server_host='',
@@ -120,8 +122,8 @@ class URLBuilder:
         return NoAuthAuthenticator()
 
     @classmethod
-    def get_network_check_url(cls) -> str:
+    def get_network_check_url(cls) -> Optional[str]:
         """Return the the network check url"""
         if cls.__hasAuth:
-            return cls.__http_base
+            return cls.__network_check_url
         return None

--- a/ibm_appconfiguration/configurations/internal/utils/validators.py
+++ b/ibm_appconfiguration/configurations/internal/utils/validators.py
@@ -15,12 +15,14 @@
 """
 This module provides methods to perform the input validations.
 """
-
 import yaml
+from schema import Schema, Optional, SchemaError, And
 from .logger import Logger
+
 
 class Validators:
     """Validator class"""
+
     @classmethod
     def validate_string(cls, value: str) -> bool:
         """Validate the string
@@ -32,7 +34,7 @@ class Validators:
 
     @classmethod
     def validate_yaml_string(cls, value: str):
-        """Validate the yaml string and retruns parsed yaml
+        """Validate the yaml string and returns parsed yaml
 
         Args:
             value: yaml string to be checked and parsed
@@ -46,3 +48,20 @@ class Validators:
             Logger.error("Error while parsing yaml string")
             Logger.error(err)
             return None
+
+    @classmethod
+    def validate_set_context_options(cls, options) -> bool:
+        """Validates the options
+
+        Args:
+            options: optional keys to be checked
+        """
+        try:
+            Schema({
+                Optional('persistent_cache_dir'): And(str, lambda s: len(s) > 0),
+                Optional('bootstrap_file'): And(str, lambda s: len(s) > 0),
+                Optional('live_config_update_enabled'): bool
+            }).validate(options)
+            return True
+        except SchemaError:
+            return False

--- a/ibm_appconfiguration/configurations/models/configuration_type.py
+++ b/ibm_appconfiguration/configurations/models/configuration_type.py
@@ -18,6 +18,7 @@ This module defines the model of a type of a feature flag or property defined in
 
 import enum
 
+
 class ConfigurationType(enum.Enum):
     """Type of data in the Feature and Property"""
     NUMERIC = 'NUMERIC'

--- a/ibm_appconfiguration/version.py
+++ b/ibm_appconfiguration/version.py
@@ -15,4 +15,4 @@
 """
 Version of ibm-appconfiguration-python-sdk
 """
-__version__ = '0.2.2'
+__version__ = '0.2.3'

--- a/integration_tests/test_integration.py
+++ b/integration_tests/test_integration.py
@@ -65,7 +65,10 @@ class MyTestCase(unittest.TestCase):
     def test_app_configuration_with_file(self):
         FILE = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'user.json')
 
-        self.sut.set_context(self.collection_id, self.environment_id, FILE, False)
+        self.sut.set_context(self.collection_id, self.environment_id, options={
+            'bootstrap_file': FILE,
+            'live_config_update_enabled': False
+        })
         time.sleep(2.0)
         self.app_configuration_actions()
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ requests>=2.20,<3.0
 websocket-client==0.57.0
 ibm-cloud-sdk-core>=3.10.0
 pyyaml>=5.4.1
+schema>=0.7.5

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@
 from setuptools import setup, find_packages
 
 NAME = "ibm-appconfiguration-python-sdk"
-VERSION = "0.2.2"
+VERSION = "0.2.3"
 # To install the library, run the following
 #
 # python setup.py install
@@ -25,7 +25,8 @@ REQUIRES = [
     "requests>=2.20,<3.0",
     "websocket-client==0.57.0",
     "ibm-cloud-sdk-core>=3.10.0",
-    "pyyaml>=5.4.1"
+    "pyyaml>=5.4.1",
+    "schema>=0.7.5"
 ]
 with open("README.md", "r", encoding="utf-8") as fh:
     long_description = fh.read()

--- a/unit_tests/configurations/test_configuration_handler.py
+++ b/unit_tests/configurations/test_configuration_handler.py
@@ -29,11 +29,16 @@ class MyTestCase(unittest.TestCase):
         self.responses.start()
         self.addCleanup(self.responses.stop)
         self.addCleanup(self.responses.reset)
+        URLBuilder.set_auth_type(False)
         self.sut = ConfigurationHandler.get_instance()
-        self.sut.load_data()
-        self.sut.init("apikey", "guid", "region", None)
+        self.sut.init("region", "guid", "apikey", None)
         FILE = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'user.json')
-        self.sut.set_context("collectionId", "environmentId", FILE, False)
+        options = {
+            'persistent_cache_dir': None,
+            'bootstrap_file': FILE,
+            'live_config_update_enabled': False
+        }
+        self.sut.set_context("collectionId", "environmentId", options)
         self.sut.load_data()
         time.sleep(2.5)
 
@@ -42,7 +47,6 @@ class MyTestCase(unittest.TestCase):
 
     def test_load_from_web(self):
         Metering.get_instance().set_repeat_calls(False)
-        URLBuilder.set_auth_type(False)
         mock_response = '''
             {
                 "features": [
@@ -71,14 +75,19 @@ class MyTestCase(unittest.TestCase):
                 "segments": []
             }
         '''
-        url = 'https://cloud.ibm.com/apprapp/feature/v1/instances/guid/collections/collection_id/config?environment_id=environment_id'
+        url = 'https://region.apprapp.cloud.ibm.com/apprapp/feature/v1/instances/guid/collections/collection_id/config?environment_id=environment_id'
         self.responses.add(responses.GET,
                            url,
                            body=mock_response,
                            content_type='application/json',
                            status=200)
-        self.sut.init("apikey", "guid", "region", "https://cloud.ibm.com")
-        self.sut.set_context("collection_id", "environment_id", None, True)
+        self.sut.init("region", "guid", "apikey", None)
+        options = {
+            'persistent_cache_dir': None,
+            'bootstrap_file': None,
+            'live_config_update_enabled': True
+        }
+        self.sut.set_context("collection_id", "environment_id", options)
         self.sut.load_data()
         features = self.sut.get_features()
         self.assertEqual(len(features), 1)
@@ -167,7 +176,6 @@ class MyTestCase(unittest.TestCase):
     # for both properties and features
     def test_yaml_evaluation(self):
         Metering.get_instance().set_repeat_calls(False)
-        URLBuilder.set_auth_type(False)
         mock_response = '''
             {
                 "features": [
@@ -237,14 +245,19 @@ class MyTestCase(unittest.TestCase):
                 ]
             }
         '''
-        url = 'https://cloud.ibm.com/apprapp/feature/v1/instances/guid/collections/collection_id/config?environment_id=environment_id'
+        url = 'https://region.apprapp.cloud.ibm.com/apprapp/feature/v1/instances/guid/collections/collection_id/config?environment_id=environment_id'
         self.responses.add(responses.GET,
                            url,
                            body=mock_response,
                            content_type='application/json',
                            status=200)
-        self.sut.init("apikey", "guid", "region", "https://cloud.ibm.com")
-        self.sut.set_context("collection_id", "environment_id", None, True)
+        self.sut.init("region", "guid", "apikey", None)
+        options = {
+            'persistent_cache_dir': None,
+            'bootstrap_file': None,
+            'live_config_update_enabled': True
+        }
+        self.sut.set_context("collection_id", "environment_id", options)
         self.sut.load_data()
         features = self.sut.get_features()
         properties = self.sut.get_properties()

--- a/unit_tests/configurations/utils/test_api_manager.py
+++ b/unit_tests/configurations/utils/test_api_manager.py
@@ -39,11 +39,10 @@ class MyTestCase(unittest.TestCase):
                                            apikey="apiekey")
         URLBuilder.set_auth_type(False)
         self.api_manager = APIManager.get_instance()
-        self.api_manager.setup_base()
 
     def test_get_call(self):
         mock_response = '{ "features": [], "properties": [], "segments": []}'
-        url = 'https://cloud.ibm.com/apprapp/feature/v1/instances/guid/collections/collection_id/config?environment_id=environment_id'
+        url = 'https://region.apprapp.cloud.ibm.com/apprapp/feature/v1/instances/guid/collections/collection_id/config?environment_id=environment_id'
         self.responses.add(responses.GET,
                       url,
                       body=mock_response,

--- a/unit_tests/test_appconfiguration.py
+++ b/unit_tests/test_appconfiguration.py
@@ -22,7 +22,7 @@ from ibm_appconfiguration.configurations.internal.utils.url_builder import URLBu
 class MyTestCase(unittest.TestCase):
 
     def setUp(self):
-        URLBuilder.set_auth_type()
+        URLBuilder.set_auth_type(False)
 
     def test_configuration(self):
         sut1 = AppConfiguration.get_instance()
@@ -35,16 +35,16 @@ class MyTestCase(unittest.TestCase):
         sut1.init(None, "guid_value", "apikey_value")
         self.assertIsNotNone(sut1.get_region())
 
-        sut1.init('us-south', None, "apikey_value")
+        sut1.init('region', None, "apikey_value")
         self.assertIsNotNone(sut1.get_guid())
 
-        sut1.init('us-south', "guid_value", None)
+        sut1.init('region', "guid_value", None)
         self.assertIsNotNone(sut1.get_apikey())
 
-        sut1.init('us-south', "guid_value", "apikey_value")
+        sut1.init('region', "guid_value", "apikey_value")
         self.assertEqual(sut1.get_guid(), "guid_value")
         self.assertEqual(sut1.get_apikey(), "apikey_value")
-        self.assertEqual(sut1.get_region(), "us-south")
+        self.assertEqual(sut1.get_region(), "region")
 
     def test_configuration_fetch(self):
         sut1 = AppConfiguration.get_instance()
@@ -68,11 +68,11 @@ class MyTestCase(unittest.TestCase):
 
     def test_configuration_get_features(self):
         sut1 = AppConfiguration.get_instance()
-        sut1.init('us-south', "guid_value", "apikey_value")
+        sut1.init('region', "guid_value", "apikey_value")
         sut1.enable_debug(True)
 
         FILE = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'user.json')
-        sut1.set_context("collectionId", "environmentId", FILE, False)
+        sut1.set_context("collectionId", "environmentId", configuration_file=FILE, live_config_update_enabled=False)
         time.sleep(2.5)
 
         self.assertEqual(len(sut1.get_features()), 3)


### PR DESCRIPTION
Description

1. The existing method of storing the configurations in a cache file is removed, instead by default all the configuration are stored in runtime memory variables.
2. Deprecated the "configuration_file" & "live_config_update_enabled" arguments of set_context() method. A DeprecationWarning will be console logged when these arguments are used by the users.
3. An Optional "options" arguments is introduced to set_context() method, users can now use this argument to store the copy last known configurations in a persistent location of their own.
4. Version updated to 0.2.3