### PR TITLE
make sdk compatible with websocket-client latest version

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2024-03-16T19:18:18Z",
+  "generated_at": "2024-10-04T11:15:02Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"

--- a/ibm_appconfiguration/configurations/internal/utils/socket.py
+++ b/ibm_appconfiguration/configurations/internal/utils/socket.py
@@ -44,7 +44,7 @@ class Socket:
         )
         self.ws_client.run_forever(sslopt={"cert_reqs": ssl.CERT_NONE})
 
-    def on_message(self, message):
+    def on_message(self, _, message):
         """Socket on-message
 
         Args:
@@ -54,7 +54,7 @@ class Socket:
             return
         self.__callback(message=message)
 
-    def on_error(self, error):
+    def on_error(self, _, error):
         """Socket on-error
 
         Args:
@@ -63,11 +63,11 @@ class Socket:
         self.__callback(error_state=error)
         self.ws_client.close()
 
-    def on_close(self):
+    def on_close(self, _, close_status_code, close_msg):
         """Socket on-close call"""
         self.__callback(closed_state='Closed the web_socket')
 
-    def on_open(self):
+    def on_open(self, _):
         """Socket on-open call"""
         self.__callback(open_state='Opened the web_socket')
 

--- a/ibm_appconfiguration/version.py
+++ b/ibm_appconfiguration/version.py
@@ -15,4 +15,4 @@
 """
 Version of ibm-appconfiguration-python-sdk
 """
-__version__ = '0.3.3'
+__version__ = '0.3.4'

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,5 @@
 # test dependencies
-responses>=0.24.1
+responses>=0.25.3
 pylint>=1.4.4
 python-dotenv>=0.17.1
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 python_dateutil>=2.8,<3.0.0
-requests>=2.31.0,<3.0
-websocket-client==0.57.0
-ibm-cloud-sdk-core>=3.18.0,<4.0.0
+requests>=2.32.2,<3.0
+websocket-client>=1.8.0,<2.0.0
+ibm-cloud-sdk-core>=3.20.3,<4.0.0
 pyyaml>=5.4.1
 schema>=0.7.5
 mmh3==3.0.0

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@
 from setuptools import setup, find_packages
 
 NAME = "ibm-appconfiguration-python-sdk"
-VERSION = "0.3.3"
+VERSION = "0.3.4"
 # To install the library, run the following
 #
 # python setup.py install
@@ -22,9 +22,9 @@ VERSION = "0.3.3"
 
 REQUIRES = [
     "python-dateutil>=2.8,<3.0.0",
-    "requests>=2.31.0,<3.0",
-    "websocket-client==0.57.0",
-    "ibm-cloud-sdk-core>=3.18.0,<4.0.0",
+    "requests>=2.32.2,<3.0",
+    "websocket-client>=1.8.0,<2.0.0",
+    "ibm-cloud-sdk-core>=3.20.3,<4.0.0",
     "pyyaml>=5.4.1",
     "schema>=0.7.5",
     "mmh3==3.0.0"

--- a/unit_tests/configurations/utils/test_socket.py
+++ b/unit_tests/configurations/utils/test_socket.py
@@ -32,23 +32,23 @@ class MyTestCase(unittest.TestCase):
     def test_socket(self):
         self.__socket = Socket()
         self.__socket.setup(
-            url="",
+            url="ws://testurl.com",
             headers=[],
             callback=self.callback
         )
 
         self.assertIsNotNone(self.__socket)
 
-        self.__socket.on_message("Socket message")
+        self.__socket.on_message(self.__socket.ws_client,"Socket message")
         self.assertEqual(self.expected_message, "Socket message")
 
-        self.__socket.on_error("Error message")
+        self.__socket.on_error(self.__socket.ws_client, "Error message")
         self.assertEqual(self.expected_error, "Error message")
 
-        self.__socket.on_open()
+        self.__socket.on_open(self.__socket.ws_client)
         self.assertEqual(self.expected_open_state, "Opened the web_socket")
 
-        self.__socket.on_close()
+        self.__socket.on_close(self.__socket.ws_client, 1000, "normal closure")
         self.assertEqual(self.expected_closed_state, "Closed the web_socket")
 
 


### PR DESCRIPTION
Issue:
https://github.com/websocket-client/websocket-client/issues/668
https://github.com/websocket-client/websocket-client/issues/669

Description:
- This SDK is now comaptible with `websocket-client` version 1.8.0 https://pypi.org/project/websocket-client/#history
- unit test updated accordingly
- end to end tested the change
- new release version is v0.3.4 (patch version upgrade)