### PR TITLE
Update mmh3 version from 3.0.0 to 5.0.1, SDK version from 0.3.4 to 0.3.5, patch README.md

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2024-10-04T11:15:02Z",
+  "generated_at": "2024-10-17T11:22:30Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"

--- a/README.md
+++ b/README.md
@@ -149,14 +149,14 @@ Use the `feature.get_current_value(entity_id=entity_id, entity_attributes=entity
 value of the feature flag. This method returns one of the Enabled/Disabled/Overridden value based on the evaluation. The
 data type of returned value matches that of feature flag.
 
-    ```py
-    entity_id = "john_doe"
-    entity_attributes = {
-      'city': 'Bangalore',
-      'country': 'India'
-    }
-    feature_value = feature.get_current_value(entity_id=entity_id, entity_attributes=entity_attributes)
-    ```
+```py
+entity_id = "john_doe"
+entity_attributes = {
+    'city': 'Bangalore',
+    'country': 'India'
+}
+feature_value = feature.get_current_value(entity_id=entity_id, entity_attributes=entity_attributes)
+```
 
 - entity_id: Id of the Entity. This will be a string identifier related to the Entity against which the feature is
   evaluated. For example, an entity might be an instance of an app that runs on a mobile device, a microservice that
@@ -190,14 +190,14 @@ Use the `property.get_current_value(entity_id=entity_id, entity_attributes=entit
 value of the property. This method returns the default property value or its overridden value based on the evaluation.
 The data type of returned value matches that of property.
 
-    ```py
-    entity_id = "john_doe"
-    entity_attributes = {
+```py
+entity_id = "john_doe"
+entity_attributes = {
     'city': 'Bangalore',
     'country': 'India'
-    }
-    property_value = property.get_current_value(entity_id=entity_id, entity_attributes=entity_attributes)
-    ```
+}
+property_value = property.get_current_value(entity_id=entity_id, entity_attributes=entity_attributes)
+```
 
 - entity_id: Id of the Entity. This will be a string identifier related to the Entity against which the property is
   evaluated. For example, an entity might be an instance of an app that runs on a mobile device, a microservice that
@@ -324,7 +324,6 @@ def configuration_update(self):
     # new_value = feature.get_current_value(entity_id, entity_attributes)
 
 appconfig_client.register_configuration_update_listener(configuration_update)
-
 ```
 
 ## Fetch latest data

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,4 @@ websocket-client>=1.8.0,<2.0.0
 ibm-cloud-sdk-core>=3.20.3,<4.0.0
 pyyaml>=5.4.1
 schema>=0.7.5
-mmh3==3.0.0
+mmh3==5.0.1

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@
 from setuptools import setup, find_packages
 
 NAME = "ibm-appconfiguration-python-sdk"
-VERSION = "0.3.4"
+VERSION = "0.3.5"
 # To install the library, run the following
 #
 # python setup.py install
@@ -27,7 +27,7 @@ REQUIRES = [
     "ibm-cloud-sdk-core>=3.20.3,<4.0.0",
     "pyyaml>=5.4.1",
     "schema>=0.7.5",
-    "mmh3==3.0.0"
+    "mmh3==5.0.1"
 ]
 with open("README.md", "r", encoding="utf-8") as fh:
     long_description = fh.read()


### PR DESCRIPTION
- Update mmh3 library version from 3.0.0 to 5.0.1
    - Verified hash function functionality has remained same in both versions

- Patched README.md file contents

- Changed patch version of this library from 0.3.4 to 0.3.5 in setup.py