### PR TITLE
Maximum recursion depth error Fix

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2024-10-17T11:22:30Z",
+  "generated_at": "2024-11-15T05:01:17Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"

--- a/ibm_appconfiguration/configurations/internal/common/config_messages.py
+++ b/ibm_appconfiguration/configurations/internal/common/config_messages.py
@@ -38,5 +38,5 @@ FEATURE_INVALID = "Invalid feature_id - "
 NO_INTERNET_CONNECTION_ERROR = 'No connection to internet. Please re-connect.'
 PROPERTY_INVALID = "Invalid property_id - "
 CONFIGURATIONS_FETCH_SUCCESS = "Successfully fetched the configurations."
-RETRY_AFTER_TEN_MINUTES = "Failed to fetch the configurations. Retrying after 10 minutes."
+RETRY_AFTER_TWO_MINUTES = "Failed to fetch the configurations. Retrying after 2 minutes."
 INPUT_PARAMETER_NOT_BOOLEAN = "Input parameter passed to use_private_endpoint() method is not boolean. Default value will be used."

--- a/ibm_appconfiguration/version.py
+++ b/ibm_appconfiguration/version.py
@@ -15,4 +15,4 @@
 """
 Version of ibm-appconfiguration-python-sdk
 """
-__version__ = '0.3.4'
+__version__ = '0.3.6'

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@
 from setuptools import setup, find_packages
 
 NAME = "ibm-appconfiguration-python-sdk"
-VERSION = "0.3.5"
+VERSION = "0.3.6"
 # To install the library, run the following
 #
 # python setup.py install


### PR DESCRIPTION
Changes from V 0.3.5 -> V 0.3.6
- Added 15s delay between each WebSocket retry
- Increased recursion depth to 40320
- Changed http server retry time from 10 minutes to 2 minutes
- Included 499 error status code in retry logic for http server